### PR TITLE
Ci tval v1

### DIFF
--- a/pfa/Makefile
+++ b/pfa/Makefile
@@ -16,11 +16,19 @@ tval_v0_QEMUFLAGS+=-kernel ${LINUX_PATH}/arch/x86_64/boot/bzImage \
 	   -initrd ${BUILD_DIR}/initramfs.cpio.gz \
 	   -no-reboot \
 	   -nographic \
-	   -append "console=ttyS0 panic=-1 loglevel=15 init='/init -c /sbin/poweroff -f'" \
+	   -append "console=ttyS0 panic=-1 loglevel=15 init='/init tval_v0'" \
 	   -device pci-testdev \
 	   -netdev user,id=mynet0 \
 	   -device rtl8139,netdev=mynet0,mac=${MAC_ADDRESS}
 
+tval_v1_QEMUFLAGS+=-kernel ${LINUX_PATH}/arch/x86_64/boot/bzImage \
+	   -initrd ${BUILD_DIR}/initramfs.cpio.gz \
+	   -no-reboot \
+	   -nographic \
+	   -append "console=ttyS0 panic=-1 loglevel=15 init='/init tval_v1" \
+	   -device pci-testdev \
+	   -netdev user,id=mynet0 \
+	   -device rtl8139,netdev=mynet0,mac=${MAC_ADDRESS}
 
 UNAME_S := $(shell uname -s)
 
@@ -83,12 +91,26 @@ cstart: cbuild
 # Validation test for v0 of the rust driver
 rtval_v0: rbuild
 	(qemu-system-x86_64 ${tval_v0_QEMUFLAGS} | grep "tval_v0|${MAC_ADDRESS}" 2>/dev/null >/dev/null) \
-		|| (echo "Couldn't find the tag 'tval_v0|${MAC_ADDRESS}' in kernel logs"; exit 1)
+		|| (echo "Couldn't find the tag 'tval_v0|${MAC_ADDRESS}' in kernel logs"; exit 1) \
+		&& echo -e "\n OK - tvalv0\n"
 
 # Validation test for v0 of the C driver
 ctval_v0: cbuild
 	(qemu-system-x86_64 ${tval_v0_QEMUFLAGS} | grep "tval_v0|${MAC_ADDRESS}" 2>/dev/null >/dev/null) \
-		|| (echo "Couldn't find the tag 'tval_v0|${MAC_ADDRESS}' in kernel logs"; exit 1)
+		|| (echo "Couldn't find the tag 'tval_v0|${MAC_ADDRESS}' in kernel logs"; exit 1) \
+		&& echo -e "\n OK - tvalv0\n"
+
+# Validation test for v1 of the rust driver
+rtval_v1: rbuild
+	(qemu-system-x86_64 ${tval_v1_QEMUFLAGS} | grep "tval_v1|${MAC_ADDRESS}" 2>/dev/null >/dev/null) \
+		|| (echo -e "\n KO - tvalv1 Couldn't find the tag 'tval_v1|${MAC_ADDRESS}' in tval_v1 logs\n"; exit 1) \
+		&& echo -e "\n OK - tvalv1\n"
+
+# Validation test for v1 of the C driver
+ctval_v1: cbuild
+	(qemu-system-x86_64 ${tval_v1_QEMUFLAGS} | grep "tval_v1|${MAC_ADDRESS}" 2>/dev/null >/dev/null) \
+		|| (echo -e "\n KO - tvalv1 Couldn't find the tag 'tval_v1|${MAC_ADDRESS}' in tval_v1 logs\n"; exit 1) \
+		&& echo -e "\n OK - tvalv1\n"
 
 # Check if all dependencies are installed, recommand to use ${DEP_CMD} otherwise
 check_deps: ${REQ_CMD_TARGETS}

--- a/pfa/mk/init.sh
+++ b/pfa/mk/init.sh
@@ -14,13 +14,13 @@ Boot took $(cut -d' ' -f1 /proc/uptime) seconds
 if [ "$1" = "tval_v0" ]
 then
 	# Force init kill to stop the vm
-	exec echo ''
+	exit 0
 elif [ "$1" = "tval_v1" ]
 then
 	# Print the machine ip adress using /sbin/ip
 	echo "ctval_v1|`/sbin/ip addr show eth0 | grep -oE '([0-9a-z]{2}:){5}[0-9a-z]{2}' | head -n 1`";
 	# Force init kill to stop the vm
-	exec echo ''
+	exit 0
 fi
 
 

--- a/pfa/mk/init.sh
+++ b/pfa/mk/init.sh
@@ -10,4 +10,18 @@ Welcome to Micro Linux!
 Boot took $(cut -d' ' -f1 /proc/uptime) seconds
 
 !
+
+if [ "$1" = "tval_v0" ]
+then
+	# Force init kill to stop the vm
+	exec echo ''
+elif [ "$1" = "tval_v1" ]
+then
+	# Print the machine ip adress using /sbin/ip
+	echo "ctval_v1|`/sbin/ip addr show eth0 | grep -oE '([0-9a-z]{2}:){5}[0-9a-z]{2}' | head -n 1`";
+	# Force init kill to stop the vm
+	exec echo ''
+fi
+
+
 exec /bin/sh $@


### PR DESCRIPTION
Updated the way tests are executed : 

* Now, you pass in the first arg to init the test you want to run (`tval_v<number>`)
* Added test for v1
* Added a line "OK - " when the test passed
* The duplication of the qemu flags will eventually get reformatted when necessary, but for now I think we can keep that how it is